### PR TITLE
Fix widgets disconnect

### DIFF
--- a/.changeset/lovely-roses-dance.md
+++ b/.changeset/lovely-roses-dance.md
@@ -1,0 +1,7 @@
+---
+'thebe-react': minor
+'thebe-lite': minor
+'demo-simple': minor
+---
+
+Clients no longer have to explicitly supply `litePluginSettings` unless they explicitly want to override them. This simplifies upgrades as clients should just bump packages, and the correct plugin settings for the bundled pyodide kernel will be applied by default.

--- a/.changeset/selfish-feet-travel.md
+++ b/.changeset/selfish-feet-travel.md
@@ -1,0 +1,5 @@
+---
+'thebe-lite': minor
+---
+
+Upgrading `@jupyterlite/pyodide-kernel-extension` to fix ipywidget disconnect issues.

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -19,18 +19,6 @@
         }
       }
     </script>
-    <script id="jupyter-config-data" type="application/json">
-      {
-        "litePluginSettings": {
-          "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl"
-          }
-        },
-        "enableMemoryStorage": true,
-        "settingsStorageDrivers": ["memoryStorageDriver"]
-      }
-    </script>
     <!-- this following is the thebe entrypoint script -->
     <script src="thebe-lite.min.js"></script>
     <script src="index.js"></script>

--- a/apps/simple/static/index.html
+++ b/apps/simple/static/index.html
@@ -23,8 +23,8 @@
       {
         "litePluginSettings": {
           "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/piplite-0.4.2-py3-none-any.whl"
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json"],
+            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl"
           }
         },
         "enableMemoryStorage": true,

--- a/apps/simple/static/ipywidgets-lite.html
+++ b/apps/simple/static/ipywidgets-lite.html
@@ -15,8 +15,8 @@
       {
         "litePluginSettings": {
           "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/piplite-0.4.2-py3-none-any.whl"
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json"],
+            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl"
           }
         },
         "enableMemoryStorage": true,

--- a/apps/simple/static/ipywidgets-lite.html
+++ b/apps/simple/static/ipywidgets-lite.html
@@ -11,18 +11,6 @@
         useBinder: false
       }
     </script>
-    <script id="jupyter-config-data" type="application/json">
-      {
-        "litePluginSettings": {
-          "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl"
-          }
-        },
-        "enableMemoryStorage": true,
-        "settingsStorageDrivers": ["memoryStorageDriver"]
-      }
-    </script>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"

--- a/apps/simple/static/lite.html
+++ b/apps/simple/static/lite.html
@@ -15,8 +15,8 @@
       {
         "litePluginSettings": {
           "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/piplite-0.4.2-py3-none-any.whl"
+            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json"],
+            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl"
           }
         },
         "enableMemoryStorage": true,

--- a/apps/simple/static/lite.html
+++ b/apps/simple/static/lite.html
@@ -11,18 +11,6 @@
         useBinder: false
       }
     </script>
-    <script id="jupyter-config-data" type="application/json">
-      {
-        "litePluginSettings": {
-          "@jupyterlite/pyodide-kernel-extension:kernel": {
-            "pipliteUrls": ["https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json"],
-            "pipliteWheelUrl": "https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl"
-          }
-        },
-        "enableMemoryStorage": true,
-        "settingsStorageDrivers": ["memoryStorageDriver"]
-      }
-    </script>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6877,14 +6877,14 @@
       }
     },
     "node_modules/@jupyterlite/contents": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.4.1.tgz",
-      "integrity": "sha512-PSDm307yT3zhMC+3R3fxM+tmD3sRZtAFDD12BLHotQ6xHWwyuac/oWxw7V2LKc1rDnWgRzmaGFxUyVjhQrnzrQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/contents/-/contents-0.4.5.tgz",
+      "integrity": "sha512-p9SGe/WpJJRNgJTzQwiQ7xIIlzgfTFy9EhncPxnaGh/5XNHVmJvQR2obip6TgNohv7/DXnPhjV+yqUg5c/ugbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/nbformat": "~4.2.5",
         "@jupyterlab/services": "~7.2.5",
-        "@jupyterlite/localforage": "^0.4.1",
+        "@jupyterlite/localforage": "^0.4.5",
         "@lumino/coreutils": "^2.2.0",
         "@types/emscripten": "^1.39.6",
         "localforage": "^1.9.0",
@@ -6892,9 +6892,9 @@
       }
     },
     "node_modules/@jupyterlite/kernel": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/kernel/-/kernel-0.4.1.tgz",
-      "integrity": "sha512-fMjQhHJRUlAKjQGld1STOf1beBQvs4vIrZJMqV+2Dkf/6kpxYTvveyRmeK8ST1O9ANpbD8mv8uNt1yZBrL9Ovg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/kernel/-/kernel-0.4.5.tgz",
+      "integrity": "sha512-1KY+6CUTw14dGvpTKpS2SeiQM6gOrY5A0lZukvcKiyziWgSl9JqUM11avp6+qOrCII4ker9+QuoAW7YHYHhmow==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
@@ -6909,18 +6909,18 @@
       }
     },
     "node_modules/@jupyterlite/licenses": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/licenses/-/licenses-0.4.1.tgz",
-      "integrity": "sha512-vjUxND8M+4I8rMyI7+bR7sInEOzBRRblFKKTzHpn3cpy/gWlTtsJNHoeY5B+lBQzZMMDNTuzxIHgmpISi30fvg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/licenses/-/licenses-0.4.5.tgz",
+      "integrity": "sha512-hcNnVa54tKUIh5WAoEI9DB2OZ8uG96jo0GY4r71aI7UO3tDAjlQYYX3SPkgWxbUVXqK5MRVYUHUfhs99dE5JOA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5"
       }
     },
     "node_modules/@jupyterlite/localforage": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.4.1.tgz",
-      "integrity": "sha512-/m2da3Y4G7EbFkHqb+dXHxvsr4lg+GzNQyPMcnqkHZIgcCVGXKFecSqjwDxPyGSfwmIbnfILB/4HB840/UZBwg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/localforage/-/localforage-0.4.5.tgz",
+      "integrity": "sha512-lGJuBHzrboNO8/LRFmlWwoWgAiNpoDhutzgYJwnzNi95nUDCNfojwqw9mZV4TeMOhUOFKy4QiVQUFUsOnVWrTA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
@@ -6930,35 +6930,35 @@
       }
     },
     "node_modules/@jupyterlite/pyodide-kernel": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.4.2.tgz",
-      "integrity": "sha512-lG8WnI/t0+mYpUHVYT1Q6/UyAmqsC28ZDmWIjF1wvzoS0pHTgkAZ1oMQAExB8YHkaUhFdt86wXb2qfFMaPyffg==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel/-/pyodide-kernel-0.4.7.tgz",
+      "integrity": "sha512-DGw4owsUwmGd5lyBP3OsXB/yTTUSSFhPV5N52G1B+M4G3qAA8FWf8qIfUot6KwC8GHvrNybfNZ1pwLQo89AzTg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "^6.1.1",
-        "@jupyterlite/contents": "^0.4.0",
-        "@jupyterlite/kernel": "^0.4.0",
+        "@jupyterlite/contents": "^0.4.5",
+        "@jupyterlite/kernel": "^0.4.5",
         "coincident": "^1.2.3",
-        "comlink": "^4.4.1"
+        "comlink": "^4.4.2"
       }
     },
     "node_modules/@jupyterlite/pyodide-kernel-extension": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.4.2.tgz",
-      "integrity": "sha512-LPjIgtowMEkPSpBOp0s9AhPYRIn82aYKJFb1zOYqdkI3E+bSXentc41w0iqRoNb31z5iwcwTZynKzglMX/7TLw==",
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/pyodide-kernel-extension/-/pyodide-kernel-extension-0.4.7.tgz",
+      "integrity": "sha512-XU9X3+TtjcnuAzVLkUGLIgDBbWSTYH98ee3bR2fghjkT+W3ku6BAlckHsVRJ8LuUUZ9WI9SKBEyp4TlHWDCmIw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "^6.1.1",
-        "@jupyterlite/contents": "^0.4.0",
-        "@jupyterlite/kernel": "^0.4.0",
-        "@jupyterlite/pyodide-kernel": "^0.4.2",
-        "@jupyterlite/server": "^0.4.0"
+        "@jupyterlite/contents": "^0.4.5",
+        "@jupyterlite/kernel": "^0.4.5",
+        "@jupyterlite/pyodide-kernel": "^0.4.7",
+        "@jupyterlite/server": "^0.4.5"
       }
     },
     "node_modules/@jupyterlite/server": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/server/-/server-0.4.1.tgz",
-      "integrity": "sha512-kYxMUmonfFYH/7M612xZtsNxn/r04x+S6iVJXU2ZrArt95LKPTEZBLVwEiHLs+sdWuLbdjOxmy2QX3wIZk2WiA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/server/-/server-0.4.5.tgz",
+      "integrity": "sha512-yTNTRPXmfZdsmTVZTQeeaA2njz6rRBg5uitQsmQcuXvUSxo/abqoFQeh2l6R4zHlMlcKHX6FWyw4Ys2SeTW/Sg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
@@ -6967,11 +6967,11 @@
         "@jupyterlab/services": "~7.2.5",
         "@jupyterlab/settingregistry": "~4.2.5",
         "@jupyterlab/statedb": "~4.2.5",
-        "@jupyterlite/contents": "^0.4.1",
-        "@jupyterlite/kernel": "^0.4.1",
-        "@jupyterlite/session": "^0.4.1",
-        "@jupyterlite/settings": "^0.4.1",
-        "@jupyterlite/translation": "^0.4.1",
+        "@jupyterlite/contents": "^0.4.5",
+        "@jupyterlite/kernel": "^0.4.5",
+        "@jupyterlite/session": "^0.4.5",
+        "@jupyterlite/settings": "^0.4.5",
+        "@jupyterlite/translation": "^0.4.5",
         "@lumino/application": "^2.4.1",
         "@lumino/coreutils": "^2.2.0",
         "@lumino/signaling": "^2.1.3",
@@ -6979,30 +6979,30 @@
       }
     },
     "node_modules/@jupyterlite/server-extension": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/server-extension/-/server-extension-0.4.1.tgz",
-      "integrity": "sha512-ymbmnn4Aride+vNcahBVquJd3wKff8w3oP66mz/WL5qIQgwyTE4fAjts1pyiaIg5Wtd7ZEZ7fR0fHPUwtnKRYA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/server-extension/-/server-extension-0.4.5.tgz",
+      "integrity": "sha512-rVPfWg3c8EgXSsgYp+Tz7dfMKH9EcAC7GEMgPeHdlzphi7RKsMwPYCI4e2OU7cVT5qA5CO+c4HiAz3lefFsC7Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
-        "@jupyterlite/kernel": "^0.4.1",
-        "@jupyterlite/licenses": "^0.4.1",
-        "@jupyterlite/localforage": "^0.4.1",
-        "@jupyterlite/server": "^0.4.1",
-        "@jupyterlite/session": "^0.4.1",
-        "@jupyterlite/settings": "^0.4.1",
-        "@jupyterlite/translation": "^0.4.1"
+        "@jupyterlite/kernel": "^0.4.5",
+        "@jupyterlite/licenses": "^0.4.5",
+        "@jupyterlite/localforage": "^0.4.5",
+        "@jupyterlite/server": "^0.4.5",
+        "@jupyterlite/session": "^0.4.5",
+        "@jupyterlite/settings": "^0.4.5",
+        "@jupyterlite/translation": "^0.4.5"
       }
     },
     "node_modules/@jupyterlite/session": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/session/-/session-0.4.1.tgz",
-      "integrity": "sha512-zIO31eSX37DXh0nnVOc+oR2gD7MtdDvUy62dPzjibNcBDfXS5zMWOQa2UnlaGMr7eyw7fwUMubpDdd+bL7HaPQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/session/-/session-0.4.5.tgz",
+      "integrity": "sha512-zNp+0NJoyZBhDb45q+IjQjP8UqzWkgLk5E7NCyO/7x1PK+94k24nIMcKPdN372alJSypslVP24iSHMykPmeOGg==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
         "@jupyterlab/services": "~7.2.5",
-        "@jupyterlite/kernel": "^0.4.1",
+        "@jupyterlite/kernel": "^0.4.5",
         "@lumino/algorithm": "^2.0.2",
         "@lumino/coreutils": "^2.2.0"
       }
@@ -7014,23 +7014,23 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@jupyterlite/settings": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/settings/-/settings-0.4.1.tgz",
-      "integrity": "sha512-SXQVxwwRnbc5Tk+G1Qk4I/J1RgYUPeDrnjLTCGL4LBbH74xpCxlWX5/rPcUfFltDs3hfrN7Zzr/ErwQeJrstNg==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/settings/-/settings-0.4.5.tgz",
+      "integrity": "sha512-Cw7qHDuE2I3jXMQV19Shakk34zUv6b4P8CWBG9WnSPwqKVCZs0LqO8IhoL9Q6+zgY+FHgeFjwin0X5cti9Dm7g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
         "@jupyterlab/settingregistry": "~4.2.5",
-        "@jupyterlite/localforage": "^0.4.1",
+        "@jupyterlite/localforage": "^0.4.5",
         "@lumino/coreutils": "^2.2.0",
         "json5": "^2.2.0",
         "localforage": "^1.9.0"
       }
     },
     "node_modules/@jupyterlite/translation": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlite/translation/-/translation-0.4.1.tgz",
-      "integrity": "sha512-5QUr/1dq3L8VscY6+FtyvZ95lOEJslD+hjcnNRgnVasAV+YOg6DAB5DFIF95WogT4CwcPWMq5FxMIzBWMrsQYA==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@jupyterlite/translation/-/translation-0.4.5.tgz",
+      "integrity": "sha512-JEUo1mu+xkk6amRKZBYi3lv+WgKnHXb0G0AmLCBdiXelM5++6BAelhxyByujfAcbZJCrw5oM4LuHxqnS+EGHsw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@jupyterlab/coreutils": "~6.2.5",
@@ -10474,9 +10474,9 @@
       }
     },
     "node_modules/async-mutex/node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/asynckit": {
@@ -11904,9 +11904,9 @@
       }
     },
     "node_modules/comlink": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.1.tgz",
-      "integrity": "sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
       "license": "Apache-2.0"
     },
     "node_modules/commander": {
@@ -34287,10 +34287,10 @@
       "license": "MIT",
       "dependencies": {
         "@jupyterlab/coreutils": "^6.2.5",
-        "@jupyterlite/pyodide-kernel": "0.4.2",
-        "@jupyterlite/pyodide-kernel-extension": "0.4.2",
-        "@jupyterlite/server": "0.4.1",
-        "@jupyterlite/server-extension": "0.4.1",
+        "@jupyterlite/pyodide-kernel": "0.4.7",
+        "@jupyterlite/pyodide-kernel-extension": "0.4.7",
+        "@jupyterlite/server": "0.4.5",
+        "@jupyterlite/server-extension": "0.4.5",
         "hook-shell-script-webpack-plugin": "^0.1.4"
       },
       "devDependencies": {

--- a/packages/lite/package.json
+++ b/packages/lite/package.json
@@ -46,10 +46,10 @@
   "homepage": "https://github.com/executablebooks/thebe#readme",
   "dependencies": {
     "@jupyterlab/coreutils": "^6.2.5",
-    "@jupyterlite/pyodide-kernel": "0.4.2",
-    "@jupyterlite/pyodide-kernel-extension": "0.4.2",
-    "@jupyterlite/server": "0.4.1",
-    "@jupyterlite/server-extension": "0.4.1",
+    "@jupyterlite/pyodide-kernel": "0.4.7",
+    "@jupyterlite/pyodide-kernel-extension": "0.4.7",
+    "@jupyterlite/server": "0.4.5",
+    "@jupyterlite/server-extension": "0.4.5",
     "hook-shell-script-webpack-plugin": "^0.1.4"
   },
   "devDependencies": {

--- a/packages/lite/src/jlite.ts
+++ b/packages/lite/src/jlite.ts
@@ -44,9 +44,29 @@ export async function startJupyterLiteServer(config?: LiteServerConfig): Promise
    * Do not rely on a configuration being on the document body, accept configuration via arguments
    * and set options on the page config directly
    */
-  if (config?.litePluginSettings) {
-    PageConfig.setOption('litePluginSettings', JSON.stringify(config.litePluginSettings));
-  }
+  const defaultLiteConfig = {
+    litePluginSettings: {
+      '@jupyterlite/pyodide-kernel-extension:kernel': {
+        pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json'],
+        pipliteWheelUrl:
+          'https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl',
+      },
+    },
+    enableMemoryStorage: true,
+    settingsStorageDrivers: ['memoryStorageDriver'],
+  };
+  PageConfig.setOption(
+    'litePluginSettings',
+    JSON.stringify({ ...defaultLiteConfig.litePluginSettings, ...config?.litePluginSettings }),
+  );
+  PageConfig.setOption(
+    'enableMemoryStorage',
+    JSON.stringify(config?.enableMemoryStorage ?? defaultLiteConfig.enableMemoryStorage),
+  );
+  PageConfig.setOption(
+    'settingsStorageDrivers',
+    JSON.stringify(config?.settingsStorageDrivers ?? defaultLiteConfig.settingsStorageDrivers),
+  );
 
   /**
    * Seems like there are 4 different extensions we may want to handle

--- a/packages/lite/src/types.ts
+++ b/packages/lite/src/types.ts
@@ -15,7 +15,9 @@ import type { ServiceManager } from '@jupyterlab/services';
  */
 
 export type LiteServerConfig = {
-  litePluginSettings: Record<string, any>;
+  litePluginSettings?: Record<string, any>;
+  enableMemoryStorage?: boolean;
+  settingsStorageDrivers?: string[];
 };
 
 export interface ThebeLiteGlobal {

--- a/packages/react/src/ThebeServerProvider.tsx
+++ b/packages/react/src/ThebeServerProvider.tsx
@@ -89,16 +89,7 @@ export function ThebeServerProvider({
     setConnecting(true);
     if (customConnectFn) customConnectFn(server);
     else if (useBinder) server.connectToServerViaBinder(customRepoProviders);
-    else if (useJupyterLite)
-      server.connectToJupyterLiteServer({
-        litePluginSettings: {
-          '@jupyterlite/pyodide-kernel-extension:kernel': {
-            pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json'],
-            pipliteWheelUrl:
-              'https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl',
-          },
-        },
-      });
+    else if (useJupyterLite) server.connectToJupyterLiteServer();
     else server.connectToJupyterServer();
 
     server.ready.then(

--- a/packages/react/src/ThebeServerProvider.tsx
+++ b/packages/react/src/ThebeServerProvider.tsx
@@ -93,9 +93,9 @@ export function ThebeServerProvider({
       server.connectToJupyterLiteServer({
         litePluginSettings: {
           '@jupyterlite/pyodide-kernel-extension:kernel': {
-            pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/all.json'],
+            pipliteUrls: ['https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/all.json'],
             pipliteWheelUrl:
-              'https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.2/pypi/piplite-0.4.2-py3-none-any.whl',
+              'https://unpkg.com/@jupyterlite/pyodide-kernel@0.4.7/pypi/piplite-0.4.7-py3-none-any.whl',
           },
         },
       });


### PR DESCRIPTION
This PR does 2 things:

* Upgrade to the latest JupyterLite dependencies, to consume a fix to #771.
* `thebe-lite` now sets default `litePluginSettings` in alignment with the bundled `pyodide-kernel` version. This simplifies usage and upgrades for clients who no longer need to keep this  setting in sync with the package. An improvement pending dynamic loading. 